### PR TITLE
Add mobile UX improvements: gestures, route detail FAB, and UI polish

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -58,8 +58,13 @@ body,
   transition: background-color 0.2s, color 0.2s;
 }
 
+body {
+  overflow-y: hidden;
+}
+
 .main-content {
   height: calc(100vh - 60px);
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 </style>

--- a/web/src/components/common/AppHeader.vue
+++ b/web/src/components/common/AppHeader.vue
@@ -138,8 +138,24 @@
         <button class="btn-ghost sign-out-btn" @click="handleLogout">Sign out</button>
       </template>
       <template v-else>
-        <RouterLink to="/login" class="btn-ghost">Sign in</RouterLink>
-        <RouterLink to="/register" class="btn-primary">Register</RouterLink>
+        <!-- Desktop: text buttons -->
+        <RouterLink to="/login" class="btn-ghost auth-desktop">Sign in</RouterLink>
+        <RouterLink to="/register" class="btn-primary auth-desktop">Register</RouterLink>
+
+        <!-- Mobile: user icon + dropdown -->
+        <div class="auth-menu-wrap" @click.stop>
+          <button class="account-icon-btn" @click.stop="authMenuOpen = !authMenuOpen" aria-label="Sign in">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+              <circle cx="12" cy="7" r="4"/>
+            </svg>
+          </button>
+          <div v-if="authMenuOpen" class="auth-dropdown">
+            <RouterLink to="/login" class="menu-link" @click="authMenuOpen = false">Sign in</RouterLink>
+            <RouterLink to="/register" class="menu-link" @click="authMenuOpen = false">Register</RouterLink>
+          </div>
+        </div>
       </template>
     </div>
   </header>
@@ -160,6 +176,7 @@ const router = useRouter()
 
 const dropdownOpen = ref(false)
 const menuOpen = ref(false)
+const authMenuOpen = ref(false)
 
 function toggleDropdown() {
   dropdownOpen.value = !dropdownOpen.value
@@ -168,6 +185,7 @@ function toggleDropdown() {
 function handleClickOutside() {
   dropdownOpen.value = false
   menuOpen.value = false
+  authMenuOpen.value = false
 }
 
 onMounted(() => document.addEventListener('click', handleClickOutside))
@@ -208,7 +226,8 @@ function formatTime(iso: string): string {
   border-bottom: 1px solid var(--color-border);
   gap: 1.5rem;
   z-index: 100;
-  position: relative;
+  position: sticky;
+  top: 0;
 }
 
 .header-left {
@@ -586,6 +605,28 @@ function formatTime(iso: string): string {
   margin-top: 0.25rem;
 }
 
+/* ─── Auth menu (mobile user icon + dropdown) ───────────────────────────────── */
+
+.auth-menu-wrap {
+  display: none;
+  position: relative;
+}
+
+.auth-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 140px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: 200;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
 /* ── Mobile ─────────────────────────────────────────────────────────────────── */
 
 @media (max-width: 600px) {
@@ -643,6 +684,14 @@ function formatTime(iso: string): string {
   .header-actions {
     gap: 0.4rem;
     margin-left: auto;
+  }
+
+  .auth-desktop {
+    display: none;
+  }
+
+  .auth-menu-wrap {
+    display: block;
   }
 }
 </style>

--- a/web/src/components/map/MapContainer.vue
+++ b/web/src/components/map/MapContainer.vue
@@ -166,12 +166,17 @@ const mapStore = useMapStore()
 const routeStore = useRouteStore()
 const serviceAlertStore = useServiceAlertStore()
 
+const emit = defineEmits<{
+  'set-destination': [payload: { name: string; lat: number; lng: number }]
+}>()
+
 const reportVehicle = ref<VehiclePosition | null>(null)
 const showLegend = ref(false)
 const overlayOpen = ref(false)
 const layersFabWrap = ref<HTMLElement | null>(null)
 const locatingUser = ref(false)
 let userLocationMarker: google.maps.Marker | null = null
+let poiInfoWindow: google.maps.InfoWindow | null = null
 
 async function goToCurrentLocation() {
   if (!map.value || !('geolocation' in navigator) || locatingUser.value) return
@@ -399,6 +404,7 @@ onMounted(async () => {
     styles: mapStore.mapTypeId === 'roadmap' ? darkMapStyles : [],
     disableDefaultUI: true,
     zoomControl: window.innerWidth > 768,
+    gestureHandling: 'greedy',
   })
 
   transitLayer = new google.maps.TransitLayer()
@@ -420,6 +426,85 @@ onMounted(async () => {
     } else {
       mapStore.nearbyStops = []
     }
+  })
+
+  // Intercept POI clicks — replace "View on Google Maps" with "Set destination"
+  poiInfoWindow = new google.maps.InfoWindow()
+  map.value.addListener('click', (event: google.maps.MapMouseEvent & { placeId?: string }) => {
+    if (!event.placeId) return
+    event.stop?.()
+
+    const location = event.latLng
+    if (!location) return
+
+    const service = new google.maps.places.PlacesService(map.value!)
+    service.getDetails(
+      { placeId: event.placeId, fields: ['name', 'formatted_address', 'geometry'] },
+      (place, status) => {
+        if (status !== google.maps.places.PlacesServiceStatus.OK || !place) return
+
+        const name = place.name ?? ''
+        const address = place.formatted_address ?? ''
+        const lat = place.geometry?.location?.lat() ?? location.lat()
+        const lng = place.geometry?.location?.lng() ?? location.lng()
+
+        const cs = getComputedStyle(document.documentElement)
+        const bg      = cs.getPropertyValue('--color-surface').trim()
+        const text    = cs.getPropertyValue('--color-text').trim()
+        const muted   = cs.getPropertyValue('--color-text-muted').trim()
+        const border  = cs.getPropertyValue('--color-border').trim()
+        const primary = cs.getPropertyValue('--color-primary').trim()
+
+        const content = `
+          <div style="font-family:sans-serif;padding:6px 6px 6px;min-width:160px;max-width:220px;background:${bg};">
+            <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:6px;margin-bottom:2px;">
+              <div style="font-weight:600;font-size:0.8rem;color:${text};line-height:1.3">${name}</div>
+              <button id="poi-close" style="background:none;border:none;color:${muted};font-size:0.85rem;cursor:pointer;padding:0;line-height:1;flex-shrink:0;margin-top:1px">✕</button>
+            </div>
+            <div style="font-size:0.72rem;color:${muted};margin-bottom:6px">${address}</div>
+            <button
+              id="poi-set-dest"
+              style="background:${primary};color:#fff;border:none;border-radius:5px;padding:5px 10px;font-size:0.75rem;font-weight:500;cursor:pointer;width:100%"
+            >Set destination</button>
+          </div>`
+
+        poiInfoWindow!.setContent(content)
+        poiInfoWindow!.setPosition(location)
+        poiInfoWindow!.open(map.value)
+
+        google.maps.event.addListenerOnce(poiInfoWindow!, 'domready', () => {
+          // Strip Google's built-in InfoWindow chrome
+          const iwInner = document.querySelector('.gm-style-iw-c') as HTMLElement | null
+          const iwOuter = document.querySelector('.gm-style-iw-d') as HTMLElement | null
+          const iwTail  = document.querySelector('.gm-style-iw-tc') as HTMLElement | null
+          if (iwInner) {
+            iwInner.style.cssText += 'padding:0!important;box-shadow:none!important;'
+          }
+          if (iwOuter) {
+            iwOuter.style.cssText += 'overflow:hidden!important;padding:0!important;max-height:none!important;'
+          }
+          if (iwTail) iwTail.style.display = 'none'
+
+          // Hide Google's default close button (it reserves top space even when hidden)
+          const defaultClose = document.querySelector('.gm-ui-hover-effect') as HTMLElement | null
+          if (defaultClose) {
+            defaultClose.style.cssText += 'display:none!important;width:0!important;height:0!important;'
+          }
+          // Also collapse the wrapper that pads for the close button
+          const iwChrome = document.querySelector('.gm-style-iw-chr') as HTMLElement | null
+          if (iwChrome) iwChrome.style.cssText += 'display:none!important;height:0!important;'
+
+          document.getElementById('poi-close')?.addEventListener('click', () => {
+            poiInfoWindow!.close()
+          })
+
+          document.getElementById('poi-set-dest')?.addEventListener('click', () => {
+            poiInfoWindow!.close()
+            emit('set-destination', { name: name || address, lat, lng })
+          })
+        })
+      },
+    )
   })
 
   mapReady.value = true

--- a/web/src/components/transit/RouteDetailModal.vue
+++ b/web/src/components/transit/RouteDetailModal.vue
@@ -164,7 +164,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { weatherService } from '@/services/weatherService'
 import { useAuthStore } from '@/stores/authStore'
 import { useRouteStore } from '@/stores/routeStore'
@@ -182,7 +182,30 @@ const props = defineProps<{
   result: google.maps.DirectionsResult
 }>()
 
-defineEmits<{ close: [], select: [] }>()
+const emit = defineEmits<{ close: [], select: [] }>()
+
+// ── Android back-gesture / browser back button support ────────────────────────
+let historyPushed = false
+
+function onPopState() {
+  historyPushed = false
+  emit('close')
+}
+
+onMounted(() => {
+  history.pushState({ routeDetailOpen: true }, '')
+  historyPushed = true
+  window.addEventListener('popstate', onPopState)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('popstate', onPopState)
+  // If modal was closed by ✕ / backdrop (not back gesture), pop the state we pushed
+  if (historyPushed) {
+    historyPushed = false
+    history.back()
+  }
+})
 
 const leg = computed(() => props.result.routes[routeStore.selectedRouteIndex]?.legs[0])
 
@@ -596,7 +619,8 @@ const fareBreakdown = computed(() => {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
-  min-width: 160px;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .fare-line {
@@ -605,6 +629,18 @@ const fareBreakdown = computed(() => {
   align-items: center;
   font-size: 0.8rem;
   color: var(--color-text-muted);
+  gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .modal-footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .fare-breakdown {
+    width: 100%;
+  }
 }
 
 .fare-mode {
@@ -630,5 +666,24 @@ const fareBreakdown = computed(() => {
   padding-top: 0.2rem;
   font-weight: 700;
   color: var(--color-text);
+}
+
+@media (max-width: 768px) {
+  .modal-backdrop {
+    padding: 0.5rem;
+  }
+
+  .timeline {
+    padding: 0.75rem 0.75rem;
+  }
+
+  .tl-row {
+    grid-template-columns: 3rem 1.25rem 1fr;
+  }
+
+  .tl-time {
+    padding-right: 0.35rem;
+    font-size: 0.68rem;
+  }
 }
 </style>

--- a/web/src/components/transit/RouteSearchPanel.vue
+++ b/web/src/components/transit/RouteSearchPanel.vue
@@ -31,14 +31,7 @@
     <!-- To field -->
     <div class="field">
       <label class="field-label">To</label>
-      <div class="input-wrap">
-        <input
-          ref="destInputEl"
-          class="field-input"
-          type="text"
-          placeholder="Destination…"
-          autocomplete="off"
-        />
+      <div class="dest-row">
         <button
           v-if="auth.isLoggedIn && destPlace"
           class="btn-heart"
@@ -47,6 +40,21 @@
           :disabled="savingDest"
           @click="saveDestination"
         >{{ destSaved ? '♥' : '♡' }}</button>
+        <div class="input-wrap">
+          <input
+            ref="destInputEl"
+            class="field-input"
+            type="text"
+            placeholder="Destination…"
+            autocomplete="off"
+          />
+        </div>
+        <button
+          v-if="showClearDest"
+          class="btn-clear-dest"
+          title="Clear destination"
+          @click="clearDestination"
+        >✕</button>
       </div>
 
       <!-- Saved location chips -->
@@ -65,70 +73,89 @@
 
     <!-- Time options -->
     <div class="time-section">
-      <!-- Depart / Arrive toggle — hidden when Leave now is checked -->
-      <div v-if="!leaveNow" class="time-toggle">
+      <!-- Leave Now / Schedule Trip toggle -->
+      <div class="trip-mode-toggle">
         <button
           class="toggle-btn"
-          :class="{ active: timeType === 'depart' }"
-          @click="timeType = 'depart'"
-        >Depart at</button>
+          :class="{ active: tripMode === 'now' }"
+          @click="tripMode = 'now'"
+        >Leave Now</button>
         <button
           class="toggle-btn"
-          :class="{ active: timeType === 'arrive' }"
-          @click="timeType = 'arrive'"
-        >Arrive by</button>
+          :class="{ active: tripMode === 'schedule' }"
+          @click="tripMode = 'schedule'"
+        >Schedule Trip</button>
       </div>
 
-      <!-- Date + time row — hidden when Leave now is checked -->
-      <div v-if="!leaveNow" class="datetime-row">
-        <!-- Date selector -->
-        <div class="date-pill" @click="openDatePicker" title="Select date">
-          <span class="date-pill-text">{{ formattedDate }}</span>
-          <span class="pill-arrow">▾</span>
-          <!-- Native date input hidden beneath the pill; triggered by click -->
-          <input
-            ref="dateInputEl"
-            class="hidden-date-input"
-            type="date"
-            v-model="selectedDate"
-            :min="todayStr"
-          />
+      <!-- Depart / Arrive + date/time — only shown when scheduling -->
+      <template v-if="tripMode === 'schedule'">
+        <div class="time-toggle">
+          <button
+            class="toggle-btn"
+            :class="{ active: timeType === 'depart' }"
+            @click="timeType = 'depart'"
+          >Depart at</button>
+          <button
+            class="toggle-btn"
+            :class="{ active: timeType === 'arrive' }"
+            @click="timeType = 'arrive'"
+          >Arrive by</button>
         </div>
 
-        <!-- Time selector -->
-        <div class="time-pill">
-          <select class="time-select" v-model="selectedHour" aria-label="Hour">
-            <option v-for="h in hours" :key="h" :value="h">{{ h }}</option>
-          </select>
-          <span class="time-colon">:</span>
-          <select class="time-select" v-model="selectedMinute" aria-label="Minute">
-            <option v-for="m in minutes" :key="m" :value="m">{{ m }}</option>
-          </select>
-          <div class="ampm-toggle">
-            <button
-              class="ampm-btn"
-              :class="{ active: selectedAmPm === 'AM' }"
-              @click="selectedAmPm = 'AM'"
-            >AM</button>
-            <button
-              class="ampm-btn"
-              :class="{ active: selectedAmPm === 'PM' }"
-              @click="selectedAmPm = 'PM'"
-            >PM</button>
+        <div class="datetime-row">
+          <div class="date-pill" @click="openDatePicker" title="Select date">
+            <span class="date-pill-text">{{ formattedDate }}</span>
+            <span class="pill-arrow">▾</span>
+            <input
+              ref="dateInputEl"
+              class="hidden-date-input"
+              type="date"
+              v-model="selectedDate"
+              :min="todayStr"
+            />
+          </div>
+
+          <div class="time-pill">
+            <select class="time-select" v-model="selectedHour" aria-label="Hour">
+              <option v-for="h in hours" :key="h" :value="h">{{ h }}</option>
+            </select>
+            <span class="time-colon">:</span>
+            <select class="time-select" v-model="selectedMinute" aria-label="Minute">
+              <option v-for="m in minutes" :key="m" :value="m">{{ m }}</option>
+            </select>
+            <div class="ampm-toggle">
+              <button
+                class="ampm-btn"
+                :class="{ active: selectedAmPm === 'AM' }"
+                @click="selectedAmPm = 'AM'"
+              >AM</button>
+              <button
+                class="ampm-btn"
+                :class="{ active: selectedAmPm === 'PM' }"
+                @click="selectedAmPm = 'PM'"
+              >PM</button>
+            </div>
           </div>
         </div>
-      </div>
-
-      <!-- Leave now checkbox — always below the date/time inputs -->
-      <label class="leave-now-label">
-        <input type="checkbox" v-model="leaveNow" />
-        Leave now
-      </label>
+      </template>
     </div>
 
     <!-- Transit options -->
     <div class="transit-options">
-      <div class="options-row">
+      <button class="options-toggle" @click="routeOptionsOpen = !routeOptionsOpen">
+        <span>Route Options</span>
+        <svg
+          class="options-chevron"
+          :class="{ open: routeOptionsOpen }"
+          xmlns="http://www.w3.org/2000/svg" width="14" height="14"
+          viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      <div v-if="routeOptionsOpen" class="options-row">
         <div class="options-col">
           <div class="options-label">Prefer</div>
           <label class="option-item" v-for="mode in transitModes" :key="mode.value">
@@ -141,7 +168,11 @@
           <div class="options-label">Routes</div>
           <label class="option-item" v-for="pref in routePreferences" :key="pref.value">
             <input type="radio" name="route-pref" :value="pref.value" v-model="selectedPreference" />
-            <span>{{ pref.label }}</span>
+            <span v-if="pref.value !== 'WHEELCHAIR'">{{ pref.label }}</span>
+            <span v-else class="wheelchair-label" :title="pref.label">
+              <span class="wheelchair-badge">♿</span>
+              Accessible
+            </span>
           </label>
         </div>
       </div>
@@ -170,18 +201,25 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouteStore } from '@/stores/routeStore'
 import { useAuthStore } from '@/stores/authStore'
 import { loadGoogleMaps } from '@/services/mapsService'
 import RouteSummaryCard from './RouteSummaryCard.vue'
 import RouteDetailModal from './RouteDetailModal.vue'
 
+const props = defineProps<{
+  pendingDestination?: { name: string; lat: number; lng: number } | null
+}>()
+
 const routeStore = useRouteStore()
 const auth = useAuthStore()
 const isPlanning = ref(false)
 
-const emit = defineEmits<{ 'view-on-map': [] }>()
+const emit = defineEmits<{
+  'view-on-map': []
+  'destination-applied': []
+}>()
 
 function onSelectRoute() {
   showDetail.value = false
@@ -283,8 +321,10 @@ const destInputEl = ref<HTMLInputElement | null>(null)
 // ── Time selection state ──────────────────────────────────────────────────────
 
 type TimeType = 'depart' | 'arrive'
+type TripMode = 'now' | 'schedule'
 const timeType = ref<TimeType>('depart')
-const leaveNow = ref(false)
+const tripMode = ref<TripMode>('now')
+const routeOptionsOpen = ref(false)
 
 // Date — default to today
 const todayStr = new Date().toISOString().slice(0, 10)
@@ -349,7 +389,7 @@ const formattedDate = computed(() => {
 })
 
 function buildTransitTime(): Date {
-  if (leaveNow.value) return new Date()
+  if (tripMode.value === 'now') return new Date()
   const d = new Date(selectedDate.value + 'T00:00:00')
   let h = parseInt(selectedHour.value, 10)
   if (selectedAmPm.value === 'PM' && h !== 12) h += 12
@@ -369,6 +409,18 @@ const AC_OPTIONS: google.maps.places.AutocompleteOptions = {
   fields: ['geometry', 'name', 'formatted_address'],
   componentRestrictions: { country: 'us' },
 }
+
+watch(() => props.pendingDestination, (dest) => {
+  if (!dest || !destInputEl.value) return
+  destInputEl.value.value = dest.name
+  destPlace.value = {
+    name: dest.name,
+    formatted_address: dest.name,
+    geometry: { location: new google.maps.LatLng(dest.lat, dest.lng) },
+  }
+  destSaved.value = false
+  emit('destination-applied')
+})
 
 onMounted(async () => {
   await loadGoogleMaps()
@@ -390,6 +442,15 @@ onMounted(async () => {
   // Auto-fill From with current location on load
   useCurrentLocation()
 })
+
+const showClearDest = computed(() => !!destPlace.value || !!routeStore.directionsResult)
+
+function clearDestination() {
+  if (destInputEl.value) destInputEl.value.value = ''
+  destPlace.value = null
+  destSaved.value = false
+  routeStore.clearPlan()
+}
 
 function swapPlaces() {
   if (!originInputEl.value || !destInputEl.value) return
@@ -513,7 +574,7 @@ function planRoute() {
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 0.5rem 2rem 0.5rem 0.6rem;
+  padding: 0.5rem 0.6rem;
   color: var(--color-text);
   font-size: 0.875rem;
   transition: border-color 0.15s;
@@ -524,14 +585,38 @@ function planRoute() {
   border-color: var(--color-primary);
 }
 
-.from-row {
+.from-row,
+.dest-row {
   display: flex;
   gap: 0.4rem;
   align-items: center;
 }
 
-.from-row .input-wrap {
+.from-row .input-wrap,
+.dest-row .input-wrap {
   flex: 1;
+}
+
+.btn-clear-dest {
+  flex-shrink: 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.btn-clear-dest:hover {
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 8%, var(--color-bg));
 }
 
 .btn-swap {
@@ -561,6 +646,14 @@ function planRoute() {
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
+}
+
+/* Leave Now / Schedule Trip top toggle */
+.trip-mode-toggle {
+  display: flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
 }
 
 /* Depart / Arrive toggle */
@@ -710,17 +803,6 @@ function planRoute() {
   color: #fff;
 }
 
-/* Leave now checkbox */
-.leave-now-label {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  user-select: none;
-}
-
 /* ── Plan button ─────────────────────────────────────────────────────────── */
 
 .btn-plan {
@@ -754,10 +836,43 @@ function planRoute() {
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 0.6rem 0.75rem;
+  overflow: hidden;
+}
+
+.options-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: color 0.15s, background 0.15s;
+}
+
+.options-toggle:hover {
+  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-primary) 6%, transparent);
+}
+
+.options-chevron {
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.options-chevron.open {
+  transform: rotate(180deg);
 }
 
 .options-row {
+  padding: 0.6rem 0.75rem 0.6rem;
+  border-top: 1px solid var(--color-border);
   display: flex;
   gap: 0.5rem;
 }
@@ -792,6 +907,18 @@ function planRoute() {
   color: var(--color-text);
   cursor: pointer;
   user-select: none;
+}
+
+.wheelchair-label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.wheelchair-badge {
+  font-size: 0.9rem;
+  line-height: 1;
+  flex-shrink: 0;
 }
 
 .option-item input[type='checkbox'],
@@ -843,24 +970,31 @@ function planRoute() {
 /* ── Heart save button ────────────────────────────────────────────────────── */
 
 .btn-heart {
-  position: absolute;
-  right: 0.5rem;
-  background: none;
-  border: none;
+  flex-shrink: 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 1rem;
   line-height: 1;
   color: var(--color-text-muted);
   cursor: pointer;
-  padding: 0.1rem;
-  transition: color 0.15s, transform 0.1s;
+  transition: color 0.15s, border-color 0.15s;
 }
 
 .btn-heart:hover {
   color: var(--color-danger);
+  border-color: var(--color-danger);
 }
 
 .btn-heart.saved {
   color: var(--color-danger);
+  border-color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 8%, var(--color-bg));
 }
 
 .btn-heart.saving {

--- a/web/src/views/AboutView.vue
+++ b/web/src/views/AboutView.vue
@@ -144,6 +144,11 @@
       <p class="footer-links">
         <RouterLink to="/privacy" class="footer-link">Privacy Policy</RouterLink>
       </p>
+      <p class="footer-links">
+        <button class="tutorial-reset-btn" @click="resetTutorial" :class="{ done: resetDone }">
+          {{ resetDone ? '✓ Tutorial will show on next visit' : '? Reset app tutorial' }}
+        </button>
+      </p>
     </section>
 
   </div>
@@ -152,6 +157,14 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import api from '@/services/api'
+
+const resetDone = ref(false)
+
+function resetTutorial() {
+  localStorage.removeItem('soundsync_tutorial_seen')
+  resetDone.value = true
+  setTimeout(() => { resetDone.value = false }, 3000)
+}
 
 interface TeamMember {
   id: string
@@ -202,10 +215,8 @@ const mission = [
 </script>
 
 <style scoped>
-/* Root scrolls within the fixed-height main-content container */
 .about-page {
-  height: 100%;
-  overflow-y: auto;
+  min-height: 100%;
 }
 
 .about-inner {
@@ -456,6 +467,28 @@ const mission = [
 
 .footer-link:hover {
   color: var(--color-primary);
+}
+
+.tutorial-reset-btn {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  width: auto;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tutorial-reset-btn:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+
+.tutorial-reset-btn.done {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 /* ── Download section ────────────────────────────────────────────────────── */

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -11,7 +11,7 @@
         class="sheet-handle"
         @click="onHandleTap"
         @touchstart.passive="onDragStart"
-        @touchmove.passive="onDragMove"
+        @touchmove.prevent="onDragMove"
         @touchend.passive="onDragEnd"
       >
         <span class="handle-bar"></span>
@@ -19,17 +19,6 @@
 
       <!-- Tabs -->
       <div class="tab-bar">
-        <button
-          class="tab-btn"
-          :class="{ active: activeTab === 'plan' }"
-          @click="activeTab = 'plan'"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
-            fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-          </svg>
-          Plan
-        </button>
         <button
           class="tab-btn"
           :class="{ active: activeTab === 'track' }"
@@ -40,6 +29,17 @@
             <rect x="1" y="3" width="15" height="13" rx="2"/><path d="M16 8h4l3 3v5h-7V8z"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/>
           </svg>
           Track
+        </button>
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'plan' }"
+          @click="activeTab = 'plan'"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+            fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+          </svg>
+          Plan
         </button>
         <button
           class="tab-btn"
@@ -55,8 +55,8 @@
       </div>
 
       <!-- Tab content -->
-      <div class="tab-content">
-        <RouteSearchPanel v-show="activeTab === 'plan'" @view-on-map="sheetOpen = false" />
+      <div class="tab-content" ref="tabContentEl" @scroll.passive="onTabScroll" @touchstart.passive="onContentTouchStart" @touchmove="onContentTouchMove">
+        <RouteSearchPanel v-show="activeTab === 'plan'" @view-on-map="sheetOpen = false" :pending-destination="pendingDestination" @destination-applied="pendingDestination = null" />
         <RouteTrackPanel  v-show="activeTab === 'track'" />
         <WeatherWidget    v-show="activeTab === 'weather'" />
       </div>
@@ -78,11 +78,40 @@
 
     <!-- Map fills remaining space -->
     <div class="map-area">
-      <MapContainer />
+      <MapContainer @set-destination="handleSetDestination" />
     </div>
 
+    <!-- Tutorial spotlight overlay -->
+    <Transition name="tutorial-fade">
+      <div v-if="showTutorial" class="tutorial-overlay"></div>
+    </Transition>
+
+    <!-- Route detail FAB (mobile only, visible when a route result exists) -->
+    <Transition name="fab-pop">
+      <button
+        v-if="routeStore.directionsResult && !showTutorial"
+        class="fab fab-route"
+        @click="showRouteDetail = true"
+        aria-label="View route details"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/>
+          <path d="M6 17V9a6 6 0 0 1 6-6h1"/><path d="M18 7v8a6 6 0 0 1-6 6h-1"/>
+        </svg>
+      </button>
+    </Transition>
+
+    <!-- Route detail modal triggered from FAB -->
+    <RouteDetailModal
+      v-if="showRouteDetail && routeStore.directionsResult"
+      :result="routeStore.directionsResult"
+      @close="showRouteDetail = false"
+      @select="showRouteDetail = false; sheetOpen = false"
+    />
+
     <!-- Mobile FAB to toggle bottom sheet -->
-    <button class="fab" @click="sheetOpen = !sheetOpen; sheetHalf = false" aria-label="Toggle panel">
+    <button class="fab" :class="{ 'fab-spotlight': showTutorial }" @click="sheetOpen = !sheetOpen; sheetHalf = false; onFabTutorialClick()" aria-label="Toggle panel">
       <svg v-if="!sheetOpen" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24"
         fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
@@ -95,25 +124,103 @@
 
     <!-- Backdrop (mobile only) -->
     <div v-if="sheetOpen" class="sheet-backdrop" @click="sheetOpen = false"></div>
+
+    <!-- First-time tutorial callout -->
+    <Transition name="tutorial-fade">
+      <div v-if="showTutorial" class="tutorial-callout">
+        <p class="tutorial-text">{{ tutorialStep === 1 ? 'Search routes for your trip.' : 'Close the Trip Planner.' }}</p>
+        <svg class="tutorial-arrow" viewBox="0 0 60 60" width="60" height="60" xmlns="http://www.w3.org/2000/svg">
+          <path d="M10 10 Q50 10 50 50" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+          <polygon points="44,54 56,44 50,50" fill="currentColor"/>
+        </svg>
+        <span class="tutorial-dismiss">Press the button to continue</span>
+      </div>
+    </Transition>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import MapContainer from '@/components/map/MapContainer.vue'
 import RouteSearchPanel from '@/components/transit/RouteSearchPanel.vue'
 import RouteTrackPanel from '@/components/transit/RouteTrackPanel.vue'
 import WeatherWidget from '@/components/weather/WeatherWidget.vue'
 import ArrivalBoard from '@/components/transit/ArrivalBoard.vue'
 import StopAlertBanner from '@/components/transit/StopAlertBanner.vue'
+import RouteDetailModal from '@/components/transit/RouteDetailModal.vue'
 import { useMapStore } from '@/stores/mapStore'
 import { useServiceAlertStore } from '@/stores/serviceAlertStore'
+import { useRouteStore } from '@/stores/routeStore'
 
 const mapStore = useMapStore()
 const serviceAlertStore = useServiceAlertStore()
+const routeStore = useRouteStore()
+const showRouteDetail = ref(false)
 const sheetOpen = ref(false)
 const sheetHalf = ref(false)
 const activeTab = ref<'plan' | 'track' | 'weather'>('plan')
+const pendingDestination = ref<{ name: string; lat: number; lng: number } | null>(null)
+const tabContentEl = ref<HTMLElement | null>(null)
+
+const tutorialStep = ref(0)
+const showTutorial = computed(() => tutorialStep.value > 0)
+
+onMounted(() => {
+  if (window.innerWidth <= 768 && !localStorage.getItem('soundsync_tutorial_seen')) {
+    tutorialStep.value = 1
+  }
+})
+
+function onFabTutorialClick() {
+  if (tutorialStep.value === 1) {
+    tutorialStep.value = 2
+  } else if (tutorialStep.value === 2) {
+    tutorialStep.value = 0
+    localStorage.setItem('soundsync_tutorial_seen', '1')
+  }
+}
+
+function dismissTutorial() {
+  tutorialStep.value = 0
+  localStorage.setItem('soundsync_tutorial_seen', '1')
+}
+
+function onTabScroll() {
+  if (window.innerWidth > 768) return
+  const el = tabContentEl.value
+  if (!el) return
+  const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 8
+  if (atBottom) {
+    sheetOpen.value = false
+    sheetHalf.value = false
+  }
+}
+
+let contentTouchStartY = 0
+
+function onContentTouchStart(e: TouchEvent) {
+  contentTouchStartY = e.touches[0].clientY
+}
+
+function onContentTouchMove(e: TouchEvent) {
+  if (window.innerWidth > 768) return
+  const el = tabContentEl.value
+  if (!el) return
+  const atTop = el.scrollTop <= 0
+  const swipingDown = e.touches[0].clientY > contentTouchStartY
+  if (atTop && swipingDown) {
+    e.preventDefault()
+    sheetOpen.value = false
+    sheetHalf.value = false
+  }
+}
+
+function handleSetDestination(payload: { name: string; lat: number; lng: number }) {
+  pendingDestination.value = payload
+  activeTab.value = 'plan'
+  sheetOpen.value = true
+  sheetHalf.value = false
+}
 
 // ── Drag to resize bottom sheet ───────────────────────────────────────────
 const dragging = ref(false)
@@ -148,17 +255,14 @@ function onDragMove(e: TouchEvent) {
 function onDragEnd() {
   if (!dragging.value) return
   dragging.value = false
-  const vh = window.innerHeight
-  const peekY = vh * 0.8 - 36
-  const halfY = vh * 0.3
-  const fullY = 0
-  const snapPoints = [fullY, halfY, peekY]
-  const nearest = snapPoints.reduce((a, b) =>
-    Math.abs(b - dragY.value) < Math.abs(a - dragY.value) ? b : a
-  )
-  if (nearest === fullY) { sheetOpen.value = true;  sheetHalf.value = false }
-  else if (nearest === halfY) { sheetOpen.value = false; sheetHalf.value = true }
-  else { sheetOpen.value = false; sheetHalf.value = false }
+  const swipingUp = dragY.value < dragStartTranslateY
+  if (swipingUp) {
+    sheetOpen.value = true
+    sheetHalf.value = false
+  } else {
+    sheetOpen.value = false
+    sheetHalf.value = false
+  }
 }
 
 const stopAlerts = computed(() => {
@@ -192,6 +296,37 @@ watch(activeTab, (tab) => {
   if (window.innerWidth > 768) return
   if (tab === 'track' && !sheetOpen.value && !sheetHalf.value) {
     sheetHalf.value = true
+  }
+})
+
+// ── Android back-gesture / browser back button support for bottom sheet ───
+let sheetHistoryPushed = false
+
+function onSheetPopState() {
+  sheetHistoryPushed = false
+  window.removeEventListener('popstate', onSheetPopState)
+  sheetOpen.value = false
+  sheetHalf.value = false
+}
+
+watch(sheetOpen, (isOpen) => {
+  if (window.innerWidth > 768) return
+  if (isOpen && !sheetHistoryPushed) {
+    history.pushState({ sheetOpen: true }, '')
+    sheetHistoryPushed = true
+    window.addEventListener('popstate', onSheetPopState)
+  } else if (!isOpen && sheetHistoryPushed) {
+    sheetHistoryPushed = false
+    window.removeEventListener('popstate', onSheetPopState)
+    history.back()
+  }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('popstate', onSheetPopState)
+  if (sheetHistoryPushed) {
+    sheetHistoryPushed = false
+    history.back()
   }
 })
 </script>
@@ -255,6 +390,7 @@ watch(activeTab, (tab) => {
   flex: 1;
   overflow-y: auto;
   padding: 1rem;
+  overscroll-behavior: none;
 }
 
 .map-area {
@@ -347,6 +483,7 @@ watch(activeTab, (tab) => {
     width: 100%;
     height: 80vh;
     border-right: none;
+    overscroll-behavior: none;
     border-top: 1px solid var(--color-border);
     border-radius: 16px 16px 0 0;
     padding: 0;
@@ -396,6 +533,7 @@ watch(activeTab, (tab) => {
     justify-content: center;
     align-items: center;
     padding: 0.6rem 0 0.4rem;
+    touch-action: none;
     cursor: pointer;
     flex-shrink: 0;
   }
@@ -430,6 +568,104 @@ watch(activeTab, (tab) => {
   .fab:hover {
     background: var(--color-primary-hover);
     transform: scale(1.05);
+  }
+
+  /* Route detail FAB — sits above the main search FAB */
+  .fab-route {
+    bottom: 130px;
+    background: var(--color-surface);
+    color: var(--color-primary);
+    border: 2px solid var(--color-primary);
+  }
+
+  .fab-route:hover {
+    background: color-mix(in srgb, var(--color-primary) 12%, var(--color-surface));
+    transform: scale(1.05);
+  }
+
+  /* Pop in/out animation for route FAB */
+  .fab-pop-enter-active,
+  .fab-pop-leave-active {
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .fab-pop-enter-from,
+  .fab-pop-leave-to {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+
+  /* ── Tutorial overlay (greys out everything incl. header) ── */
+  .tutorial-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    z-index: 110;
+    pointer-events: all;
+  }
+
+  /* FAB lifted above overlay during tutorial */
+  .fab-spotlight {
+    z-index: 115 !important;
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.65);
+    animation: fab-breathe 0.9s ease-in-out infinite;
+  }
+
+  @keyframes fab-breathe {
+    0%, 100% { filter: brightness(1); transform: scale(1); }
+    50%       { filter: brightness(1.45); transform: scale(1.08); }
+  }
+
+  /* ── Tutorial callout ── */
+  .tutorial-callout {
+    z-index: 116 !important;
+    pointer-events: none;
+    position: fixed;
+    bottom: 130px;
+    right: 0.75rem;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+    cursor: pointer;
+    pointer-events: all;
+  }
+
+  .tutorial-text {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 10px 14px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    line-height: 1.4;
+    max-width: 200px;
+    text-align: right;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+  }
+
+  .tutorial-arrow {
+    color: var(--color-primary);
+    margin-right: 12px;
+  }
+
+  .tutorial-dismiss {
+    font-size: 0.68rem;
+    color: var(--color-text-muted);
+    margin-right: 4px;
+  }
+
+  .tutorial-fade-enter-active,
+  .tutorial-fade-leave-active {
+    transition: opacity 0.4s ease, transform 0.4s ease;
+  }
+
+  .tutorial-fade-enter-from,
+  .tutorial-fade-leave-to {
+    opacity: 0;
+    transform: translateY(10px);
   }
 
   /* Backdrop */

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -15,13 +15,23 @@
         </div>
         <div class="field">
           <label class="field-label">Password</label>
-          <input
-            v-model="form.password"
-            class="field-input"
-            type="password"
-            required
-            autocomplete="current-password"
-          />
+          <div class="input-wrap">
+            <input
+              v-model="form.password"
+              class="field-input"
+              :type="showPassword ? 'text' : 'password'"
+              required
+              autocomplete="current-password"
+            />
+            <button type="button" class="eye-btn" @click="showPassword = !showPassword" :aria-label="showPassword ? 'Hide password' : 'Show password'">
+              <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>
+              </svg>
+              <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>
+              </svg>
+            </button>
+          </div>
         </div>
 
         <p v-if="error" class="error-msg">{{ error }}</p>
@@ -36,7 +46,6 @@
         <RouterLink to="/register">Register here</RouterLink>
       </p>
 
-      <p class="tony-signature">— Tony</p>
     </div>
   </div>
 </template>
@@ -52,6 +61,7 @@ const route = useRoute()
 const form = reactive({ email: '', password: '' })
 const loading = ref(false)
 const error = ref('')
+const showPassword = ref(false)
 
 async function submit() {
   loading.value = true
@@ -123,17 +133,42 @@ async function submit() {
   color: var(--color-text-muted);
 }
 
+.input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 .field-input {
+  width: 100%;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 0.65rem 0.75rem;
+  padding: 0.65rem 2.25rem 0.65rem 0.75rem;
   color: var(--color-text);
   font-size: 0.9rem;
 }
 
 .field-input:focus {
+  outline: none;
   border-color: var(--color-primary);
+}
+
+.eye-btn {
+  position: absolute;
+  right: 0.6rem;
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.15s;
+}
+
+.eye-btn:hover {
+  color: var(--color-text);
 }
 
 .error-msg {
@@ -168,11 +203,4 @@ async function submit() {
   color: var(--color-text-muted);
 }
 
-.tony-signature {
-  text-align: right;
-  margin-top: 1rem;
-  font-size: 0.8rem;
-  font-style: italic;
-  color: var(--color-text-muted);
-}
 </style>

--- a/web/src/views/ScoreView.vue
+++ b/web/src/views/ScoreView.vue
@@ -355,8 +355,7 @@ function delayLvlLabel(val: number): string {
 
 <style scoped>
 .score-page {
-  height: 100%;
-  overflow-y: auto;
+  min-height: 100%;
   padding: 1.5rem 2rem;
   display: flex;
   flex-direction: column;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: '0.0.0.0',
     port: 5173,
     proxy: {
       '/api': {


### PR DESCRIPTION
- Intercept Android back gesture to close bottom sheet and route detail modal instead of navigating away
- Add floating route detail FAB above search FAB that appears after getting directions
- Add clear (X) button to destination field that resets the trip plan
- Move heart save button outside the destination input as a separate circle button
- Fix fare breakdown overflow on mobile with responsive stacked layout
- Narrow timeline time column on mobile to give more space to route description
- Add gestureHandling greedy for single-finger map panning on mobile
- Replace Sign In/Register with user icon dropdown on mobile
- Add Leave Now / Schedule Trip toggle, collapsible Route Options
- Add first-time tutorial overlay with FAB spotlight and breathing animation
- Add password reveal toggle on login page
- Fix double scroll on About and Score pages, make AppHeader sticky
- Add reset tutorial button in About page footer