### PR TITLE
add transit assistant chatbot to mobile (iOS + Android)

### DIFF
--- a/mobile/lib/screens/chat_screen.dart
+++ b/mobile/lib/screens/chat_screen.dart
@@ -1,0 +1,374 @@
+import 'package:flutter/material.dart';
+import '../services/chat_service.dart';
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({super.key});
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final _service = ChatService();
+  final _messages = <ChatMessage>[];
+  final _controller = TextEditingController();
+  final _scrollController = ScrollController();
+  bool _loading = false;
+
+  static const _bg = Color(0xFF0D1B2A);
+  static const _card = Color(0xFF122340);
+  static const _border = Color(0xFF1E3A5F);
+
+  Future<void> _send() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty || _loading) return;
+
+    setState(() {
+      _messages.add(ChatMessage(role: 'user', content: text));
+      _loading = true;
+    });
+    _controller.clear();
+    _scrollToBottom();
+
+    try {
+      final reply = await _service.send(_messages);
+      setState(() => _messages.add(ChatMessage(role: 'assistant', content: reply)));
+    } catch (e) {
+      setState(() => _messages.add(ChatMessage(
+        role: 'assistant',
+        content: 'Sorry, something went wrong. Please try again.',
+      )));
+    } finally {
+      setState(() => _loading = false);
+      _scrollToBottom();
+    }
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: _bg,
+      appBar: AppBar(
+        backgroundColor: _card,
+        surfaceTintColor: Colors.transparent,
+        title: const Row(
+          children: [
+            Text('🚌', style: TextStyle(fontSize: 20)),
+            SizedBox(width: 8),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Transit Assistant',
+                  style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
+                ),
+                Text(
+                  'Powered by Claude Haiku',
+                  style: TextStyle(color: Color(0xFF7FDBFF88 & 0xFFFFFFFF), fontSize: 11),
+                ),
+              ],
+            ),
+          ],
+        ),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(1),
+          child: Container(height: 1, color: _border),
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _messages.isEmpty
+                ? _EmptyState()
+                : ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.all(16),
+                    itemCount: _messages.length + (_loading ? 1 : 0),
+                    itemBuilder: (context, i) {
+                      if (_loading && i == _messages.length) {
+                        return const _TypingIndicator();
+                      }
+                      return _MessageBubble(message: _messages[i]);
+                    },
+                  ),
+          ),
+          _InputBar(
+            controller: _controller,
+            loading: _loading,
+            onSend: _send,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+class _EmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('🚌', style: TextStyle(fontSize: 48)),
+            const SizedBox(height: 16),
+            const Text(
+              'Transit Assistant',
+              style: TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Ask me anything about getting around\nthe Seattle/Bellevue area.',
+              style: TextStyle(color: Colors.white54, fontSize: 14),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: const Color(0xFF122340),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: const Color(0xFF1E3A5F)),
+              ),
+              child: const Text(
+                '"I need to go to Seattle Center\nfrom Bellevue College today"',
+                style: TextStyle(
+                  color: Color(0xFF7FDBFF),
+                  fontSize: 13,
+                  fontStyle: FontStyle.italic,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Message bubble ───────────────────────────────────────────────────────────
+
+class _MessageBubble extends StatelessWidget {
+  final ChatMessage message;
+  const _MessageBubble({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final isUser = message.role == 'user';
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Align(
+        alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+        child: Container(
+          constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.8),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: isUser ? const Color(0xFF7FDBFF) : const Color(0xFF122340),
+            borderRadius: BorderRadius.only(
+              topLeft: const Radius.circular(14),
+              topRight: const Radius.circular(14),
+              bottomLeft: Radius.circular(isUser ? 14 : 3),
+              bottomRight: Radius.circular(isUser ? 3 : 14),
+            ),
+            border: isUser ? null : Border.all(color: const Color(0xFF1E3A5F)),
+          ),
+          child: Text(
+            message.content,
+            style: TextStyle(
+              color: isUser ? const Color(0xFF0D1B2A) : const Color(0xFFC8DFF0),
+              fontSize: 14,
+              height: 1.5,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Typing indicator ─────────────────────────────────────────────────────────
+
+class _TypingIndicator extends StatefulWidget {
+  const _TypingIndicator();
+
+  @override
+  State<_TypingIndicator> createState() => _TypingIndicatorState();
+}
+
+class _TypingIndicatorState extends State<_TypingIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(vsync: this, duration: const Duration(milliseconds: 900))
+      ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            color: const Color(0xFF122340),
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(14),
+              topRight: Radius.circular(14),
+              bottomRight: Radius.circular(14),
+              bottomLeft: Radius.circular(3),
+            ),
+            border: Border.all(color: const Color(0xFF1E3A5F)),
+          ),
+          child: AnimatedBuilder(
+            animation: _anim,
+            builder: (_, __) => Row(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(3, (i) {
+                final offset = ((_anim.value * 3) - i).clamp(0.0, 1.0);
+                final bounce = offset < 0.5 ? offset * 2 : (1 - offset) * 2;
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 3),
+                  child: Transform.translate(
+                    offset: Offset(0, -4 * bounce),
+                    child: Container(
+                      width: 7,
+                      height: 7,
+                      decoration: const BoxDecoration(
+                        color: Color(0xFF7FDBFF),
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Input bar ────────────────────────────────────────────────────────────────
+
+class _InputBar extends StatelessWidget {
+  final TextEditingController controller;
+  final bool loading;
+  final VoidCallback onSend;
+
+  const _InputBar({
+    required this.controller,
+    required this.loading,
+    required this.onSend,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+        12, 8, 12, 8 + MediaQuery.of(context).viewInsets.bottom,
+      ),
+      decoration: const BoxDecoration(
+        color: Color(0xFF0D1B2A),
+        border: Border(top: BorderSide(color: Color(0xFF1E3A5F))),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: controller,
+                enabled: !loading,
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+                maxLines: null,
+                textInputAction: TextInputAction.send,
+                onSubmitted: (_) => onSend(),
+                decoration: InputDecoration(
+                  hintText: 'Ask about transit routes...',
+                  hintStyle: const TextStyle(color: Color(0xFF4A6A8A)),
+                  filled: true,
+                  fillColor: const Color(0xFF122340),
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: const BorderSide(color: Color(0xFF1E3A5F)),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: const BorderSide(color: Color(0xFF1E3A5F)),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: const BorderSide(color: Color(0x887FDBFF)),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            SizedBox(
+              width: 42,
+              height: 42,
+              child: loading
+                  ? const Padding(
+                      padding: EdgeInsets.all(10),
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Color(0xFF7FDBFF),
+                      ),
+                    )
+                  : ElevatedButton(
+                      onPressed: onSend,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF7FDBFF),
+                        foregroundColor: const Color(0xFF0D1B2A),
+                        padding: EdgeInsets.zero,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                      ),
+                      child: const Icon(Icons.send_rounded, size: 18),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/main_shell.dart
+++ b/mobile/lib/screens/main_shell.dart
@@ -8,6 +8,7 @@ import 'home_screen.dart';
 import 'scores_screen.dart';
 import 'account_screen.dart';
 import 'about_screen.dart';
+import 'chat_screen.dart';
 
 class MainShell extends ConsumerStatefulWidget {
   const MainShell({super.key});
@@ -43,6 +44,8 @@ class _MainShellState extends ConsumerState<MainShell> {
                 onRegister: () => context.push('/register'),
               );
       case 3:
+        body = const ChatScreen();
+      case 4:
         body = const AboutScreen();
       default:
         body = const HomeScreen();
@@ -72,6 +75,11 @@ class _MainShellState extends ConsumerState<MainShell> {
             icon: Icon(Icons.person_outline, color: Colors.white38),
             selectedIcon: Icon(Icons.person, color: Color(0xFF7FDBFF)),
             label: 'Account',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.chat_bubble_outline, color: Colors.white38),
+            selectedIcon: Icon(Icons.chat_bubble, color: Color(0xFF7FDBFF)),
+            label: 'Assistant',
           ),
           NavigationDestination(
             icon: Icon(Icons.info_outline, color: Colors.white38),

--- a/mobile/lib/services/chat_service.dart
+++ b/mobile/lib/services/chat_service.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+import 'api_client.dart';
+
+class ChatMessage {
+  final String role; // 'user' or 'assistant'
+  final String content;
+
+  const ChatMessage({required this.role, required this.content});
+
+  Map<String, String> toJson() => {'role': role, 'content': content};
+}
+
+class ChatService {
+  final Dio _dio = buildApiClient();
+
+  Future<String> send(List<ChatMessage> history) async {
+    final res = await _dio.post('/chat', data: {
+      'messages': history.map((m) => m.toJson()).toList(),
+    });
+    return res.data['message'] as String;
+  }
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -620,18 +620,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -913,10 +913,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
Adds a dedicated Assistant tab to the bottom nav bar with a full chat screen backed by the same POST /api/v1/chat endpoint as the web. Includes animated typing indicator, message bubbles, and the dark-blue palette.