### PR TITLE
mobile: autofill + auto-trigger route from chatbot navigation intent

### DIFF
--- a/mobile/lib/providers/chat_route_provider.dart
+++ b/mobile/lib/providers/chat_route_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class PendingChatRoute {
+  final String originName;
+  final double originLat;
+  final double originLng;
+  final String destName;
+  final double destLat;
+  final double destLng;
+
+  const PendingChatRoute({
+    required this.originName,
+    required this.originLat,
+    required this.originLng,
+    required this.destName,
+    required this.destLat,
+    required this.destLng,
+  });
+}
+
+final pendingChatRouteProvider =
+    StateProvider<PendingChatRoute?>((ref) => null);
+
+final activeTabProvider = StateProvider<int>((ref) => 0);

--- a/mobile/lib/screens/chat_screen.dart
+++ b/mobile/lib/screens/chat_screen.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/chat_service.dart';
+import '../services/geocoding_service.dart';
+import '../providers/chat_route_provider.dart';
 
-class ChatScreen extends StatefulWidget {
+class ChatScreen extends ConsumerStatefulWidget {
   const ChatScreen({super.key});
 
   @override
-  State<ChatScreen> createState() => _ChatScreenState();
+  ConsumerState<ChatScreen> createState() => _ChatScreenState();
 }
 
-class _ChatScreenState extends State<ChatScreen> {
+class _ChatScreenState extends ConsumerState<ChatScreen> {
   final _service = ChatService();
   final _messages = <ChatMessage>[];
   final _controller = TextEditingController();
@@ -31,8 +34,29 @@ class _ChatScreenState extends State<ChatScreen> {
     _scrollToBottom();
 
     try {
-      final reply = await _service.send(_messages);
-      setState(() => _messages.add(ChatMessage(role: 'assistant', content: reply)));
+      final response = await _service.send(_messages);
+      setState(() => _messages.add(ChatMessage(role: 'assistant', content: response.message)));
+
+      if (response.route != null) {
+        final route = response.route!;
+        final results = await Future.wait([
+          GeocodingService.geocode(route.origin),
+          GeocodingService.geocode(route.destination),
+        ]);
+        final originResult = results[0];
+        final destResult = results[1];
+        if (originResult != null && destResult != null && mounted) {
+          ref.read(pendingChatRouteProvider.notifier).state = PendingChatRoute(
+            originName: route.origin,
+            originLat: originResult.lat,
+            originLng: originResult.lng,
+            destName: route.destination,
+            destLat: destResult.lat,
+            destLng: destResult.lng,
+          );
+          ref.read(activeTabProvider.notifier).state = 0; // switch to Map tab
+        }
+      }
     } catch (e) {
       setState(() => _messages.add(ChatMessage(
         role: 'assistant',

--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import '../providers/transit_provider.dart';
 import '../providers/location_provider.dart';
 import '../providers/auth_provider.dart';
+import '../providers/chat_route_provider.dart';
 import '../services/api_client.dart';
 import '../services/geocoding_service.dart';
 import '../services/route_planning_service.dart';
@@ -178,6 +179,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     RoutesLookup.instance.load();
     _originFocus.addListener(() {
       if (mounted) setState(() => _originFieldActive = _originFocus.hasFocus);
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.listenManual(pendingChatRouteProvider, (_, route) {
+        if (route == null || !mounted) return;
+        _originCtrl.text = route.originName;
+        _originLat = route.originLat;
+        _originLng = route.originLng;
+        _showRouteSheet(route.destName, route.destLat, route.destLng);
+        ref.read(pendingChatRouteProvider.notifier).state = null;
+      });
     });
     SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
       statusBarColor: Colors.transparent,

--- a/mobile/lib/screens/main_shell.dart
+++ b/mobile/lib/screens/main_shell.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../providers/auth_provider.dart';
+import '../providers/chat_route_provider.dart';
 import '../services/routes_lookup.dart';
 import 'home_screen.dart';
 import 'scores_screen.dart';
@@ -18,8 +19,6 @@ class MainShell extends ConsumerStatefulWidget {
 }
 
 class _MainShellState extends ConsumerState<MainShell> {
-  int _index = 0;
-
   @override
   void initState() {
     super.initState();
@@ -29,9 +28,10 @@ class _MainShellState extends ConsumerState<MainShell> {
   @override
   Widget build(BuildContext context) {
     final auth = ref.watch(authProvider);
+    final tabIndex = ref.watch(activeTabProvider);
 
     Widget body;
-    switch (_index) {
+    switch (tabIndex) {
       case 0:
         body = const HomeScreen();
       case 1:
@@ -57,8 +57,8 @@ class _MainShellState extends ConsumerState<MainShell> {
         backgroundColor: const Color(0xFF0D1B2A),
         surfaceTintColor: Colors.transparent,
         indicatorColor: const Color(0xFF7FDBFF).withOpacity(0.15),
-        selectedIndex: _index,
-        onDestinationSelected: (i) => setState(() => _index = i),
+        selectedIndex: tabIndex,
+        onDestinationSelected: (i) => ref.read(activeTabProvider.notifier).state = i,
         labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
         destinations: const [
           NavigationDestination(

--- a/mobile/lib/services/chat_service.dart
+++ b/mobile/lib/services/chat_service.dart
@@ -10,13 +10,34 @@ class ChatMessage {
   Map<String, String> toJson() => {'role': role, 'content': content};
 }
 
+class ChatRoute {
+  final String origin;
+  final String destination;
+  const ChatRoute({required this.origin, required this.destination});
+}
+
+class ChatResponse {
+  final String message;
+  final ChatRoute? route;
+  const ChatResponse({required this.message, this.route});
+}
+
 class ChatService {
   final Dio _dio = buildApiClient();
 
-  Future<String> send(List<ChatMessage> history) async {
+  Future<ChatResponse> send(List<ChatMessage> history) async {
     final res = await _dio.post('/chat', data: {
       'messages': history.map((m) => m.toJson()).toList(),
     });
-    return res.data['message'] as String;
+    final data = res.data as Map<String, dynamic>;
+    ChatRoute? route;
+    if (data['route'] != null) {
+      final r = data['route'] as Map<String, dynamic>;
+      route = ChatRoute(
+        origin: r['origin'] as String,
+        destination: r['destination'] as String,
+      );
+    }
+    return ChatResponse(message: data['message'] as String, route: route);
   }
 }

--- a/mobile/lib/services/geocoding_service.dart
+++ b/mobile/lib/services/geocoding_service.dart
@@ -62,6 +62,27 @@ class GeocodingService {
     }
   }
 
+  /// Geocodes a free-text [address] to coordinates.
+  static Future<GeocodingResult?> geocode(String address) async {
+    try {
+      final resp = await _dio.get('/geocode/json', queryParameters: {
+        'address': address,
+        'key': _mapsApiKey,
+        'components': 'country:us',
+      });
+      if (resp.data['status'] != 'OK') return null;
+      final result = (resp.data['results'] as List).first as Map<String, dynamic>;
+      final loc = result['geometry']['location'] as Map<String, dynamic>;
+      return GeocodingResult(
+        result['formatted_address'] as String,
+        (loc['lat'] as num).toDouble(),
+        (loc['lng'] as num).toDouble(),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Resolves a [placeId] to coordinates + formatted address.
   static Future<GeocodingResult?> placeDetails(String placeId) async {
     try {


### PR DESCRIPTION
When Claude detects a navigation request, ChatScreen geocodes both place names, sets pendingChatRouteProvider, and switches to the Map tab via activeTabProvider. HomeScreen listens for the pending route, fills the origin field, and calls _showRouteSheet automatically.